### PR TITLE
Fall back to unencoded commands as this is the newer default for Caldera

### DIFF
--- a/CalderaToAttire.py
+++ b/CalderaToAttire.py
@@ -43,7 +43,13 @@ def execData(data, agent):
 
 def steps(step, index):
     stepDict = dict()
-    stepDict['command'] = base64.b64decode(step['command']).decode('utf-8')
+    
+    try:
+        stepDict['command'] = base64.b64decode(step['command']).decode('utf-8')
+    except Exception as e:
+        # Newer versions of Caldera don't base64 encode by default
+        stepDict['command'] = step['command']
+        
     stepDict['executor'] = step['executor']
     stepDict['order'] = index
     date_time_str = step['agent_reported_time']


### PR DESCRIPTION
Based on [this](https://github.com/mitre/caldera/commit/adc59581cd40cae2918d32a3bd7f3b227a8422aa) commit, Caldera no longer base64 encodes command output by default.

This fix catches a failed base64 decode and just uses the raw command value. This could be replaced entirely if backwards compatibility isn't a concern.